### PR TITLE
feat: 파티 api 연동 및 파티 초대 페이지 추가

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -18,7 +18,7 @@
     <file type="web" url="file://$PROJECT_DIR$/android" />
     <type id="android" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="openjdk-23" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" default="true" project-jdk-name="openjdk-23" project-jdk-type="JavaSDK" />
   <component name="ProjectType">
     <option name="id" value="io.flutter" />
   </component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,6 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/it_contest_fe.iml" filepath="$PROJECT_DIR$/it_contest_fe.iml" />
+      <module fileurl="file://$PROJECT_DIR$/android/it_contest_fe_android.iml" filepath="$PROJECT_DIR$/android/it_contest_fe_android.iml" />
     </modules>
   </component>
 </project>

--- a/lib/core/network/dio_client.dart
+++ b/lib/core/network/dio_client.dart
@@ -5,7 +5,7 @@ import 'package:dio/dio.dart';
 class DioClient {
   final Dio _dio = Dio(BaseOptions(
     // baseUrl: 'https://ssuchaehwa.duckdns.org',
-    baseUrl: 'http://192.168.123.105:8080',
+    baseUrl: 'http://192.168.45.148:8080',
     connectTimeout: const Duration(seconds: 10),
     receiveTimeout: const Duration(seconds: 30),
     contentType: 'application/json',

--- a/lib/features/friends/model/friend_info.dart
+++ b/lib/features/friends/model/friend_info.dart
@@ -19,17 +19,19 @@ class FriendInfo {
 
   factory FriendInfo.fromJson(Map<String, dynamic> json) {
     final exp = json['exp'] ?? 0;
-    final level = exp ~/ 5000;
     final percent = ((exp % 5000) / 5000 * 100).round().clamp(0, 100);
 
     return FriendInfo(
       userId: json['userId'],
       nickname: json['nickname'] ?? '',
-      level: json['level'] ?? 0, // ✅ 서버에서 온 level 값 사용
+      level: json['level'] ?? 0,
       expPercent: percent,
       totalExp: exp,
       gold: json['gold'] ?? 0,
-      profileImageUrl: json['profileImageUrl'] ?? '',
+      profileImageUrl: (json['profileImageUrl'] != null &&
+          (json['profileImageUrl'] as String).isNotEmpty)
+          ? json['profileImageUrl']
+          : 'https://ssuchaehwa.duckdns.org/default-profile.png', // ✅ 기본 이미지 URL
     );
   }
 }

--- a/lib/features/quest/model/party_model.dart
+++ b/lib/features/quest/model/party_model.dart
@@ -1,0 +1,40 @@
+class PartyCreateRequest {
+  final String content;
+  final String questTitle; // questId 대신 제목
+  final int priority;
+  final String questType;
+  final String completionStatus;
+  final String startDate; // yyyy-MM-dd
+  final String dueDate;   // yyyy-MM-dd
+  final String startTime; // HH:mm:ss
+  final String endTime;   // HH:mm:ss
+  final List<String> hashtags;
+
+  PartyCreateRequest({
+    required this.content,
+    required this.questTitle,
+    required this.priority,
+    required this.questType,
+    required this.completionStatus,
+    required this.startDate,
+    required this.dueDate,
+    required this.startTime,
+    required this.endTime,
+    required this.hashtags,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      "content": content,
+      "questTitle": questTitle,
+      "priority": priority,
+      "questType": questType,
+      "completionStatus": completionStatus,
+      "startDate": startDate,
+      "dueDate": dueDate,
+      "startTime": startTime,
+      "endTime": endTime,
+      "hashtags": hashtags,
+    };
+  }
+}

--- a/lib/features/quest/service/party_service.dart
+++ b/lib/features/quest/service/party_service.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import '../../../core/network/dio_client.dart';
+import '../model/party_model.dart';
+
+class PartyService {
+  final Dio _dio = DioClient().dio;
+
+  // 파티 생성
+  Future<int?> createPartyQuest(PartyCreateRequest request, String accessToken) async {
+    try {
+
+      print("📤 headers = {Authorization: Bearer $accessToken}");
+
+      final response = await _dio.post(
+        "/quests/party/create",
+        data: request.toJson(),
+        options: Options(
+          headers: {
+            "Authorization": "Bearer $accessToken", // ✅ 토큰 추가
+          },
+        ),
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        // ✅ BaseResponse는 "result" 키 사용
+        return response.data["result"]["questId"];
+      }
+      return null;
+    } catch (e) {
+      print("❌ createPartyQuest error: $e");
+      return null;
+    }
+  }
+
+  // 파티원 초대
+  Future<void> inviteFriends(int partyId, List<int> friendIds, String accessToken) async {
+    try {
+      final body = jsonEncode({
+        "friendIds": friendIds, // ✅ key로 감싸서 보내야 함
+      });
+      print("📤 inviteFriends body = $body");
+
+      final response = await _dio.post(
+        "/quests/party/$partyId/invite",
+        data: body,
+        options: Options(
+          headers: {
+            "Authorization": "Bearer $accessToken",
+            "Content-Type": "application/json",
+          },
+        ),
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        print("✅ 친구 초대 성공: ${response.data}");
+      } else {
+        print("⚠️ 친구 초대 실패: ${response.statusCode} ${response.data}");
+      }
+    } catch (e) {
+      print("❌ inviteFriends error: $e");
+    }
+  }
+}

--- a/lib/features/quest/view/party_invite_page.dart
+++ b/lib/features/quest/view/party_invite_page.dart
@@ -1,0 +1,306 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../friends/viewmodel/friend_viewmodel.dart';
+
+class PartyInvitePage extends StatefulWidget {
+  const PartyInvitePage({super.key});
+
+  @override
+  State<PartyInvitePage> createState() => _PartyInvitePageState();
+}
+
+class _PartyInvitePageState extends State<PartyInvitePage> {
+  final Set<int> selectedIndexes = {}; // ✅ 여러 명 선택 가능하도록 변경
+
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(() {
+      Provider.of<FriendViewModel>(context, listen: false).fetchFriends();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios_new, color: Colors.black),
+          onPressed: () => Navigator.pop(context),
+        ),
+        centerTitle: true,
+        title: const Text(
+          '모든 친구 보기',
+          style: TextStyle(
+            color: Colors.black,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        bottom: const PreferredSize(
+          preferredSize: Size.fromHeight(1.0),
+          child: Divider(color: Colors.grey, height: 1, thickness: 1),
+        ),
+      ),
+
+      body: Consumer<FriendViewModel>(
+        builder: (context, viewModel, _) {
+          final friends = viewModel.friends;
+
+          if (friends.isEmpty) {
+            return SizedBox.expand(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  const SizedBox(height: 200),
+                  Image.asset(
+                    'assets/icons/icon1.png',
+                    width: 160,
+                    height: 160,
+                  ),
+                  const SizedBox(height: 16),
+                  const Text(
+                    '친구가 등록되어 있지 않습니다.',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      fontSize: 20,
+                      color: Colors.black,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          return ListView.builder(
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            itemCount: friends.length,
+            itemBuilder: (context, index) {
+              final friend = friends[index];
+              final isSelected = selectedIndexes.contains(index);
+
+              return GestureDetector(
+                onTap: () {
+                  setState(() {
+                    if (isSelected) {
+                      selectedIndexes.remove(index);
+                    } else {
+                      selectedIndexes.add(index);
+                    }
+                  });
+                },
+                child: Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: Container(
+                    margin: const EdgeInsets.symmetric(horizontal: 16),
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(16),
+                      border: Border.all(
+                        color: isSelected
+                            ? const Color(0xFF6737F4)
+                            : Colors.black.withOpacity(0.1),
+                        width: 2,
+                      ),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withOpacity(0.05),
+                          blurRadius: 6,
+                          offset: const Offset(0, 2),
+                        ),
+                      ],
+                    ),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(50),
+                          child: (friend.profileImageUrl.isNotEmpty)
+                              ? Image.network(
+                            friend.profileImageUrl,
+                            width: 60,
+                            height: 60,
+                            fit: BoxFit.cover,
+                            errorBuilder: (context, error, stackTrace) {
+                              return Image.asset('assets/images/simpson.jpg',
+                                  width: 60, height: 60, fit: BoxFit.cover);
+                            },
+                          )
+                              : Image.asset('assets/images/simpson.jpg',
+                              width: 60, height: 60, fit: BoxFit.cover),
+                        ),
+                        const SizedBox(width: 16),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Row(
+                                children: [
+                                  Text(
+                                    friend.nickname,
+                                    style: const TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                  const SizedBox(width: 8),
+                                  Container(
+                                    padding: const EdgeInsets.symmetric(
+                                        horizontal: 8, vertical: 2),
+                                    decoration: BoxDecoration(
+                                      color: const Color(0xFF6737F4),
+                                      borderRadius: BorderRadius.circular(8),
+                                    ),
+                                    child: Text(
+                                      'LV.${friend.level}',
+                                      style: const TextStyle(
+                                        color: Colors.white,
+                                        fontSize: 12,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              const SizedBox(height: 12),
+                              Row(
+                                children: [
+                                  Expanded(
+                                    flex: 7,
+                                    child: Container(
+                                      height: 20,
+                                      decoration: BoxDecoration(
+                                        color: Colors.white,
+                                        borderRadius: BorderRadius.circular(16),
+                                        border: Border.all(
+                                            color: const Color(0xFF6737F4),
+                                            width: 2),
+                                      ),
+                                      child: Stack(
+                                        children: [
+                                          FractionallySizedBox(
+                                            widthFactor:
+                                            friend.expPercent / 100,
+                                            child: Container(
+                                              decoration: BoxDecoration(
+                                                color: const Color(0x996737F4),
+                                                borderRadius:
+                                                BorderRadius.circular(14),
+                                              ),
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  ),
+                                  const SizedBox(width: 8),
+                                  Text(
+                                    'EXP ${friend.expPercent}%',
+                                    style: const TextStyle(
+                                      fontSize: 12,
+                                      color: Color(0xFF6737F4),
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              const SizedBox(height: 8),
+                              Row(
+                                mainAxisAlignment:
+                                MainAxisAlignment.spaceBetween,
+                                children: [
+                                  Row(
+                                    children: [
+                                      Image.asset('assets/icons/widget_icon.png',
+                                          width: 18, height: 18),
+                                      const SizedBox(width: 4),
+                                      const Text(
+                                        '누적 경험치 ',
+                                        style: TextStyle(
+                                            color: Color(0xFF6737F4),
+                                            fontSize: 13),
+                                      ),
+                                      Text(
+                                        '${friend.totalExp}',
+                                        style: const TextStyle(
+                                          color: Color(0xFF6737F4),
+                                          fontSize: 13,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                  Row(
+                                    children: [
+                                      Image.asset('assets/icons/gold_icon.png',
+                                          width: 18, height: 18),
+                                      const SizedBox(width: 4),
+                                      const Text(
+                                        '골드 ',
+                                        style: TextStyle(
+                                            color: Color(0xFF6737F4),
+                                            fontSize: 13),
+                                      ),
+                                      Text(
+                                        '${friend.gold}',
+                                        style: const TextStyle(
+                                          color: Color(0xFF6737F4),
+                                          fontSize: 13,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ],
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      ),
+
+      // 확인 버튼 (PartyInvitePage와 동일)
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ElevatedButton(
+          onPressed: selectedIndexes.isEmpty
+              ? null
+              : () {
+            final friends = context.read<FriendViewModel>().friends;
+            final selectedFriends =
+            selectedIndexes.map((i) => friends[i]).toList();
+
+            Navigator.pop(context, selectedFriends);
+          },
+          style: ElevatedButton.styleFrom(
+            backgroundColor: const Color(0xFF6737F4),
+            minimumSize: const Size(double.infinity, 50),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+          ),
+          child: const Text(
+            '확인',
+            style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+                color: Colors.white
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/quest/view/quest_party_create_screen.dart
+++ b/lib/features/quest/view/quest_party_create_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:it_contest_fe/features/quest/view/party_invite_page.dart';
 import 'package:provider/provider.dart';
 
 import 'package:it_contest_fe/shared/quest_create_form/title_input.dart';
@@ -17,7 +18,12 @@ import '../../friends/view/all_friends_page.dart';
 import '../../friends/viewmodel/friend_viewmodel.dart';
 
 class QuestPartyCreateScreen extends StatefulWidget {
-  const QuestPartyCreateScreen({super.key});
+  final List<dynamic> invitedFriends;
+
+  const QuestPartyCreateScreen({
+    super.key,
+    this.invitedFriends = const [],
+  });
 
   @override
   State<QuestPartyCreateScreen> createState() => _QuestPartyCreateScreenState();
@@ -36,6 +42,7 @@ class _QuestPartyCreateScreenState extends State<QuestPartyCreateScreen> {
     final friendVM = context.watch<FriendViewModel>();
     final friends = friendVM.friends; // FriendViewModel에서 가져오기
     final hasFriends = friends.isNotEmpty;
+    final invitedFriends = widget.invitedFriends;
 
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle.dark.copyWith(
@@ -83,29 +90,37 @@ class _QuestPartyCreateScreenState extends State<QuestPartyCreateScreen> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                // 1. 파티명
-                PartyTitleInput(onChanged: (value) => setState(() => _title = value)),
+                // 파티명 (PartyTitleInput)
+                PartyTitleInput(
+                  onChanged: (value) {
+                    vm.setContent(value); // ✅ ViewModel.content에 저장
+                  },
+                ),
                 const SizedBox(height: 16),
 
-                // 2. 퀘스트 제목
-                QuestTitleInput(onChanged: (value) => setState(() => _title = value)),
+                // 퀘스트 제목 (QuestTitleInput)
+                QuestTitleInput(
+                  onChanged: (value) {
+                    vm.setQuestTitle(value); // ✅ ViewModel.title에 저장
+                  },
+                ),
                 const SizedBox(height: 16),
 
-                // 3. 우선순위
+                // 우선순위 & 기간
                 QuestPrioritySection(
-                  onPriorityChanged: (value) => setState(() => _priority = value),
-                  onPeriodChanged: (value) => setState(() => _period = value),
+                  onPriorityChanged: (value) => vm.setPriority(value),
+                  onPeriodChanged: (value) => vm.setPeriod(value),
                   showTipBox: false,
                 ),
                 const SizedBox(height: 16),
 
-                // 4. 카테고리
-                CategoryInput(onChanged: (value) => setState(() => _categories = value)),
-                const SizedBox(height: 16),
+                // 카테고리
+                CategoryInput(onChanged: (value) => vm.setCategories(value)),
+
 
                 // 5. 날짜 및 시간
                 DateTimeSection(
-                  questType: vm.questType, // 퀘스트 타입 전달
+                  questType: vm.period, // 퀘스트 타입 전달
                   onStartDateChanged: vm.setStartDate,
                   onDueDateChanged: vm.setDueDate,
                   onStartTimeChanged: vm.setStartTime,
@@ -123,30 +138,39 @@ class _QuestPartyCreateScreenState extends State<QuestPartyCreateScreen> {
                     ),
                     const SizedBox(height: 20),
 
-                    // 🔹 버튼 (제목 바로 밑)
+                    // "파티 초대하기" 버튼 부분 수정
                     SizedBox(
                       width: 123,
                       height: 46,
                       child: OutlinedButton(
-                        onPressed: () {
-                          // TODO: 파티 초대하기 로직
+                        onPressed: () async {
+                          final selected = await Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => const PartyInvitePage(),
+                            ),
+                          );
+
+                          if (selected != null) {
+                            context.read<QuestPartyCreateViewModel>().setInvitedFriends(selected);
+                            print("✅ 초대한 친구들: $selected");
+                          }
                         },
                         style: OutlinedButton.styleFrom(
-                          foregroundColor: Color(0xFFBDBDBD), // 텍스트 색
+                          foregroundColor: const Color(0xFFBDBDBD),
                           side: const BorderSide(
-                            color: Color(0xFFBDBDBD), // Gray400 (#BDBDBD)
+                            color: Color(0xFFBDBDBD),
                             width: 1,
                           ),
                           shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(8), // round 정도 (8이 Figma 기본)
+                            borderRadius: BorderRadius.circular(8),
                           ),
-                          padding: EdgeInsets.zero, // SizedBox 크기 그대로 쓰게 하기
+                          padding: EdgeInsets.zero,
                         ),
                         child: const Text(
                           "파티 초대하기",
                           style: TextStyle(
                             fontSize: 14,
-
                           ),
                         ),
                       ),
@@ -267,27 +291,9 @@ class _QuestPartyCreateScreenState extends State<QuestPartyCreateScreen> {
                 SizedBox(
                   width: double.infinity,
                   child: ElevatedButton(
-                    onPressed: vm.isLoading
-                        ? null
-                        : () async {
-                      final success = await vm.createPartyQuest();
-                      if (success) {
-                        InterstitialAdService.showAd(
-                          onClosed: () {
-                            QuestCreationModal.show(
-                              context,
-                              onClose: () {
-                                Navigator.pushReplacementNamed(context, '/main');
-                              },
-                            );
-                          },
-                        );
-                      } else if (vm.errorMessage != null) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(content: Text(vm.errorMessage!)),
-                        );
-                      }
-                    },
+                    onPressed: vm.isFormValid && !vm.isLoading
+                        ? () => vm.handleCreate(context)
+                        : null,
                     style: ElevatedButton.styleFrom(
                       backgroundColor: const Color(0xFF7958FF),
                       shape: RoundedRectangleBorder(

--- a/lib/features/quest/viewmodel/quest_party_create_viewmodel.dart
+++ b/lib/features/quest/viewmodel/quest_party_create_viewmodel.dart
@@ -1,59 +1,161 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart'; // 🔑 토큰 저장소
+import 'package:it_contest_fe/features/quest/model/party_model.dart';
+import 'package:it_contest_fe/features/quest/service/party_service.dart';
+import 'package:it_contest_fe/shared/widgets/quest_creation_modal.dart';
 
 class QuestPartyCreateViewModel extends ChangeNotifier {
   bool isLoading = false;
   String? errorMessage;
 
-  // 퀘스트 타입 (파티 퀘스트는 기본적으로 DAILY)
-  String _questType = 'DAILY';
-  String get questType => _questType;
-  
-  void setQuestType(String type) {
-    _questType = type;
+  // 입력값 상태
+  String title = '';        // 퀘스트명 (questTitle)
+  String content = '';      // 파티 내용
+  int priority = 0;
+  String? period;
+  List<String> categories = [];
+  DateTime? startDate;
+  DateTime? dueDate;
+  TimeOfDay? startTime;
+  TimeOfDay? endTime;
+  List<dynamic> invitedFriends = [];
+
+  final FlutterSecureStorage _storage = const FlutterSecureStorage();
+
+  bool get isFormValid {
+    return title.isNotEmpty &&
+        content.isNotEmpty &&
+        priority > 0 &&
+        period != null &&
+        categories.isNotEmpty &&
+        startDate != null &&
+        dueDate != null &&
+        startTime != null &&
+        endTime != null;
+  }
+
+  // setter
+  void setQuestTitle(String value) {
+    title = value;
     notifyListeners();
   }
 
-  // 날짜, 시간 등 필요한 필드 선언 (예시)
-  DateTime? _startDate;
-  DateTime? _dueDate;
-  TimeOfDay? _startTime;
-  TimeOfDay? _endTime;
-
-  void setStartDate(DateTime? date) {
-    _startDate = date;
+  void setContent(String value) {
+    content = value;
     notifyListeners();
   }
 
-  void setDueDate(DateTime? date) {
-    _dueDate = date;
+  void setPriority(int value) {
+    priority = value;
     notifyListeners();
   }
 
-  void setStartTime(TimeOfDay? time) {
-    _startTime = time;
+  void setPeriod(String? value) {
+    period = value;
     notifyListeners();
   }
 
-  void setEndTime(TimeOfDay? time) {
-    _endTime = time;
+  void setCategories(List<String> value) {
+    categories = value;
     notifyListeners();
   }
 
-  Future<bool> createPartyQuest() async {
+  void setStartDate(DateTime date) {
+    startDate = date;
+    notifyListeners();
+  }
+
+  void setDueDate(DateTime date) {
+    dueDate = date;
+    notifyListeners();
+  }
+
+  void setStartTime(TimeOfDay time) {
+    startTime = time;
+    notifyListeners();
+  }
+
+  void setEndTime(TimeOfDay time) {
+    endTime = time;
+    notifyListeners();
+  }
+
+  void setInvitedFriends(List<dynamic> friends) {
+    invitedFriends = friends;
+    notifyListeners();
+  }
+
+  // ✅ 파티 생성 처리
+  Future<void> handleCreate(BuildContext context) async {
     isLoading = true;
-    errorMessage = null;
     notifyListeners();
+
+    final partyService = PartyService();
+
     try {
-      // TODO: 파티 퀘스트 생성 API 호출 및 로직 구현
-      await Future.delayed(const Duration(seconds: 1));
-      isLoading = false;
-      notifyListeners();
-      return true;
+      // 🔑 SecureStorage에서 accessToken 불러오기
+      final accessToken = await _storage.read(key: "accessToken");
+
+      if (accessToken == null || accessToken.isEmpty) {
+        throw Exception("로그인 토큰이 없습니다. 다시 로그인 해주세요.");
+      }
+
+      final request = PartyCreateRequest(
+        content: content,
+        questTitle: title,
+        priority: priority,
+        questType: _mapPeriodToQuestType(period),
+        completionStatus: "INCOMPLETE",
+        startDate: startDate?.toIso8601String().split("T")[0] ?? "",
+        dueDate: dueDate?.toIso8601String().split("T")[0] ?? "",
+        startTime: startTime != null
+            ? "${startTime!.hour.toString().padLeft(2, '0')}:${startTime!.minute.toString().padLeft(2, '0')}:00"
+            : "",
+        endTime: endTime != null
+            ? "${endTime!.hour.toString().padLeft(2, '0')}:${endTime!.minute.toString().padLeft(2, '0')}:00"
+            : "",
+        hashtags: categories,
+      );
+
+      final questId = await partyService.createPartyQuest(request, accessToken);
+      print("📤 questId(before) = $questId");
+      print("📤 invitedFriends(before) = $invitedFriends");
+      if (questId != null && invitedFriends.isNotEmpty) {
+        final friendIds = invitedFriends.map((f) => f.userId as int).toList();
+        await partyService.inviteFriends(questId, friendIds, accessToken);
+        print("📤 invitedFriends = $invitedFriends");
+        print("📤 questId = $questId");
+      }
+      print("📤 questId(after) = $questId");
+      print("📤 invitedFriends(after) = $invitedFriends");
+      QuestCreationModal.show(
+        context,
+        onClose: () => Navigator.pushReplacementNamed(context, '/main'),
+      );
     } catch (e) {
-      errorMessage = '파티 퀘스트 생성에 실패했습니다.';
+      errorMessage = "파티 생성 실패: $e";
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(errorMessage!)),
+      );
+    } finally {
       isLoading = false;
       notifyListeners();
-      return false;
     }
   }
-} 
+
+  String _mapPeriodToQuestType(String? period) {
+    switch (period) {
+      case "일일":
+        return "DAILY";
+      case "주간":
+        return "WEEKLY";
+      case "월간":
+        return "MONTHLY";
+      case "연간":
+        return "YEARLY";
+      default:
+        return "DAILY";
+    }
+  }
+
+}


### PR DESCRIPTION
## 📌 PR 개요
- 파티 api 연동

## 🔧 작업 내용
- 파티 생성 api
- 파티 초대 api

## 📷 테스트
<img width="1673" height="394" alt="image-20250917-220021" src="https://github.com/user-attachments/assets/593b1f6d-6954-49d9-a1fb-ab184fc3d8ca" />


## ❗추가 내용
- 이 에러 못잡아서 잠못잤는데 flutter에서 계속 400에러가 발생합니다. 400에러면 잘못 된 형식의 데이터를 전달했다는건데 어떤게 잘못됐다는 건지 잘 모르겠어서.. api연결하는 부분만 좀 봐줄 수 있으면 봐줘 파티 초대 부분이야 party_service.inviteFriends, quest_party_create_viewmodel, party_invite_page, party_model, quest_party_create_screen 보면 됩니다.. 생성 완료 버튼에 api 붙여놨어요